### PR TITLE
Ability To Change From A Windows File Path To Linux File Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 
 build
 navidrome_migrate.egg-info
-temp/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 build
 navidrome_migrate.egg-info
+temp/*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Using the `changeLink` option, this will allow you to just change all the paths 
 
 Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' 'D:\Media Server Content\'`
 
-####Moving From Windows To Linux/Mac
+###Moving From Windows To Linux/Mac
 Moving your Navidrome from a Windows machine to a Linux or Mac based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--replace-slashes` option, it will allow any \\'s (Windows path) to be replaced with /'s (Linux/Unix path).
 
 Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' '/mnt/drive/Media Server Content/' --replace-slashes`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Usage:
 6. Change the `MusicFolder`/`ND_MUSICFOLDER` variable to point to the new location of your library.
 7. Start Navidrome, and run a full scan.
 
+### Already Moved Library And Only Need File Path Changes
+Using the `changeLink` option, this will allow you to just change all the paths and md5 hashes, without moving your files. Perhaps you are moving from one system to another and the file systems may not be the same.
+
+Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' 'D:\Media Server Content\'`
+
+####Moving From Windows To Linux/Mac
+Moving your Navidrome from a Windows machine to a Linux or Mac based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--replace-slashes` option, it will allow any \\'s (Windows path) to be replaced with /'s (Linux/Unix path).
+
+Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' '/mnt/drive/Media Server Content/' --replace-slashes`
+- This will replace something such as `E:\Media Server Content\blah\blah.mp3` to `/mnt/drive/Media Server Content/blah/blah.mp3`
+
 ### Moving file/directory
 
 This is useful if you just want to move a single folder in your library.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,17 @@ Using the `changeLink` option, this will allow you to just change all the paths 
 
 Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' 'D:\Media Server Content\'`
 
-###Moving From Windows To Linux/Mac
-Moving your Navidrome from a Windows machine to a Linux or Mac based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--replace-slashes` option, it will allow any \\'s (Windows path) to be replaced with /'s (Linux/Unix path).
+### Moving From Windows To Linux/Mac
+Moving your Navidrome from a Windows machine to a Linux or Mac based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--windowsToLinuxPath` option, it will allow any \\'s (Windows path) to be replaced with /'s (Linux/Unix path).
 
-Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' '/mnt/drive/Media Server Content/' --replace-slashes`
+Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' '/mnt/drive/Media Server Content/' --windowsToLinuxPath`
 - This will replace something such as `E:\Media Server Content\blah\blah.mp3` to `/mnt/drive/Media Server Content/blah/blah.mp3`
+
+### Moving From Windows To Linux/Mac
+Moving your Navidrome from a Linux or Mac based operating system to a Windows based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--linuxPathToWindowsPath` option, it will allow any  /'s (Linux/Unix path) to be replaced with \\'s (Windows path).
+
+Example `python3 migrate.py navidrome.db changeLink '/mnt/drive/Media Server Content/' 'E:\Media Server Content\' --linuxToWindowsPath`
+- This will replace something such as `/mnt/drive/Media Server Content/blah/blah.mp3` to `E:\Media Server Content\blah\blah.mp3`
 
 ### Moving file/directory
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Using the `changeLink` option, this will allow you to just change all the paths 
 Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' 'D:\Media Server Content\'`
 
 ### Moving From Windows To Linux/Mac
-Moving your Navidrome from a Windows machine to a Linux or Mac based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--windowsToLinuxPath` option, it will allow any \\'s (Windows path) to be replaced with /'s (Linux/Unix path).
+Moving your Navidrome from a Windows machine to a Linux or Mac based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--windows_to_linux_path` option, it will allow any \\'s (Windows path) to be replaced with /'s (Linux/Unix path).
 
-Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' '/mnt/drive/Media Server Content/' --windowsToLinuxPath`
+Example `python3 migrate.py navidrome.db changeLink 'E:\Media Server Content\' '/mnt/drive/Media Server Content/' --windows_to_linux_path`
 - This will replace something such as `E:\Media Server Content\blah\blah.mp3` to `/mnt/drive/Media Server Content/blah/blah.mp3`
 
 ### Moving From Windows To Linux/Mac
-Moving your Navidrome from a Linux or Mac based operating system to a Windows based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--linuxPathToWindowsPath` option, it will allow any  /'s (Linux/Unix path) to be replaced with \\'s (Windows path).
+Moving your Navidrome from a Linux or Mac based operating system to a Windows based operating system can be a pain. If you moved your files already and, along with the `changeLink` option, use the `--linux_to_windows_path` option, it will allow any  /'s (Linux/Unix path) to be replaced with \\'s (Windows path).
 
-Example `python3 migrate.py navidrome.db changeLink '/mnt/drive/Media Server Content/' 'E:\Media Server Content\' --linuxToWindowsPath`
+Example `python3 migrate.py navidrome.db changeLink '/mnt/drive/Media Server Content/' 'E:\Media Server Content\' --linux_to_windows_path`
 - This will replace something such as `/mnt/drive/Media Server Content/blah/blah.mp3` to `E:\Media Server Content\blah\blah.mp3`
 
 ### Moving file/directory

--- a/migrate.py
+++ b/migrate.py
@@ -70,10 +70,16 @@ change_link.add_argument(
     help="The new system path to replace the old one",
 )
 change_link.add_argument(
-    "--replace-slashes",
+    "--windowsToLinuxPath",
     action="store_true",
     default=False,
     help="Replace backslashes with forward slashes in the database paths",
+)
+change_link.add_argument(
+    "--linuxToWindowsPath",
+    action="store_true",
+    default=False,
+    help="Replace forward slashes with backslashes in the database paths",
 )
 
 args = parser.parse_args()
@@ -84,6 +90,10 @@ ZERO_WIDTH_SPACE = "\u200b"
 def fail(msg: str) -> NoReturn:
     print("ERROR:", msg)
     exit(-1)
+
+# Check if both --windowsToLinuxPath and --linuxToWindowsPath are set
+if args.windowsToLinuxPath and args.linuxToWindowsPath:
+    fail("You can only set one of --windowsToLinuxPath or --linuxToWindowsPath")
 
 db_path: str = args.db_path
 old_path: str = args.old_path
@@ -181,8 +191,10 @@ try:
             for id, path in media_files:
                 new_track_path = path.replace(old_path, new_path, 1)
 
-                if args.replace_slashes:
+                if args.windowsToLinuxPath:
                     new_track_path = new_track_path.replace("\\", "/")
+                if args.linuxToWindowsPath:
+                    new_track_path = new_track_path.replace("/", "\\",)
 
                 new_id = md5(new_track_path.encode()).hexdigest()
                 execute_sql(
@@ -243,8 +255,10 @@ try:
         for id, embed, art_paths in albums:
             new_embed_path = embed.replace(old_path, new_path, 1)
 
-            if args.replace_slashes:
+            if args.windowsToLinuxPath:
                 new_embed_path = new_embed_path.replace("\\", "/")
+            if args.linuxToWindowsPath:
+                new_embed_path = new_embed_path.replace("/", "\\",)
 
 
             if art_paths:
@@ -257,8 +271,10 @@ try:
             else:
                 new_paths = art_paths
             
-            if args.replace_slashes:
-                    new_paths = new_paths.replace("\\", "/")
+            if args.windowsToLinuxPath:
+                new_paths = new_paths.replace("\\", "/")
+            if args.linuxToWindowsPath:
+                new_paths = new_paths.replace("/", "\\",)
 
             cursor.execute(
                 "UPDATE album SET embed_art_path = ?, paths = ? WHERE id = ?",
@@ -279,8 +295,10 @@ try:
             else:
                 new_image_files = image_files
 
-            if args.replace_slashes:
+            if args.windowsToLinuxPath:
                 new_image_files = new_image_files.replace("\\", "/")
+            if args.linuxToWindowsPath:
+                new_image_files = new_image_files.replace("/", "\\",)
 
             cursor.execute(
                 "UPDATE album SET image_files = ? WHERE id = ?",

--- a/migrate.py
+++ b/migrate.py
@@ -289,8 +289,8 @@ try:
                 (new_embed_path, new_paths, id),
             )
         # Update albums image_files column
-        albums = cursor.execute("SELECT id, image_files FROM album").fetchall()
-        for id, image_files, *_ in albums:
+        album_images: List[Tuple[str, str]] = cursor.execute("SELECT id, image_files FROM album").fetchall()
+        for id, image_files in album_images:
             if image_files:
                 new_image_files: str = ZERO_WIDTH_SPACE.join(
                     [

--- a/migrate.py
+++ b/migrate.py
@@ -8,14 +8,6 @@ from shutil import move as fsmove
 from traceback import print_exc
 from typing import List, Literal, NoReturn, Optional, Tuple
 
-def execute_sql(cursor, query, params=None):
-    if params:
-       #print("Executing SQL Query:", query, "with params:", params)
-        cursor.execute(query, params)
-    else:
-        #print("Executing SQL Query:", query)
-        cursor.execute(query)
-
 parser = ArgumentParser(description="Navidrome database migrator")
 parser.add_argument("db_path", help="Path to your navidrome.db")
 parser.add_argument(
@@ -106,6 +98,11 @@ try:
     conn = connect(db_path, isolation_level=None)
     try:
         cursor = conn.cursor()
+        def execute_sql(cursor, query, params=None):
+            if params:
+                cursor.execute(query, params)
+            else:
+                cursor.execute(query)
         cursor.execute("PRAGMA foreign_keys = ON")
         # Since we are messing with media file ids, this will give us trouble.
         # defer checking foreign key constraints until the end
@@ -268,7 +265,7 @@ try:
                 (new_embed_path, new_paths, id),
             )
         # Update albums image_files column
-        albums: List[Tuple[str, str, Optional[str]]] = cursor.execute(
+        albums: List[Tuple[str, str]] = cursor.execute(
             "SELECT id, image_files FROM album"
         ).fetchall()
         for id, image_files in albums:

--- a/migrate.py
+++ b/migrate.py
@@ -71,13 +71,13 @@ change_link.add_argument(
     help="The new system path to replace the old one",
 )
 change_link.add_argument(
-    "--windowsToLinuxPath",
+    "--windows_to_linux_path",
     action="store_true",
     default=False,
     help="Replace backslashes with forward slashes in the database paths",
 )
 change_link.add_argument(
-    "--linuxToWindowsPath",
+    "--linux_to_windows_path",
     action="store_true",
     default=False,
     help="Replace forward slashes with backslashes in the database paths",
@@ -97,16 +97,16 @@ db_path: str = args.db_path
 old_path: str = args.old_path
 new_path: str = args.new_path
 dry_run: bool = args.dry_run
-windowsToLinuxPath: bool = args.windowsToLinuxPath
-linuxToWindowsPath: bool = args.linuxToWindowsPath
+windows_to_linux_path: bool = args.windows_to_linux_path
+linux_to_windows_path: bool = args.linux_to_windows_path
 path_Slash_Change: List[str] = []
 
-# Check if both --windowsToLinuxPath and --linuxToWindowsPath are set
-if windowsToLinuxPath and linuxToWindowsPath:
-    fail("You can only set one of --windowsToLinuxPath or --linuxToWindowsPath")
-elif windowsToLinuxPath:
+# Check if both --windows_to_linux_path and --linux_to_windows_path are set
+if windows_to_linux_path and linux_to_windows_path:
+    fail("You can only set one of --windows_to_linux_path or --linux_to_windows_path")
+elif windows_to_linux_path:
     path_Slash_Change = ["\\", "/"]
-elif linuxToWindowsPath:
+elif linux_to_windows_path:
     path_Slash_Change = ["/", "\\"]
 
 command: Literal["move", "migrate", "changeLink"] = args.command

--- a/migrate.py
+++ b/migrate.py
@@ -5,6 +5,7 @@ from os.path import basename, isdir, join
 from pathlib import Path
 from sqlite3 import connect
 from shutil import move as fsmove
+import sqlite3
 from traceback import print_exc
 from typing import List, Literal, NoReturn, Optional, Tuple
 
@@ -113,7 +114,7 @@ try:
     try:
         cursor = conn.cursor()
 
-        def execute_sql(cursor, query, params=None) -> None:
+        def execute_sql(cursor: sqlite3.Cursor, query: str, params: str = "None") -> None:
             if params:
                 cursor.execute(query, params)
             else:

--- a/migrate.py
+++ b/migrate.py
@@ -245,6 +245,10 @@ try:
         for id, embed, art_paths in albums:
             new_embed_path = embed.replace(old_path, new_path, 1)
 
+            if args.replace_slashes:
+                new_embed_path = new_embed_path.replace("\\", "/")
+
+
             if art_paths:
                 new_paths: Optional[str] = ZERO_WIDTH_SPACE.join(
                     [
@@ -254,7 +258,14 @@ try:
                 )
             else:
                 new_paths = art_paths
+            
+            if args.replace_slashes:
+                    new_paths = new_paths.replace("\\", "/")
 
+            cursor.execute(
+                "UPDATE album SET embed_art_path = ?, paths = ? WHERE id = ?",
+                (new_embed_path, new_paths, id),
+            )
             cursor.execute(
                 "UPDATE album SET embed_art_path = ?, paths = ? WHERE id = ?",
                 (new_embed_path, new_paths, id),

--- a/migrate.py
+++ b/migrate.py
@@ -273,7 +273,9 @@ try:
                 (new_embed_path, new_paths, id),
             )
         # Update albums image_files column
-        album_images: List[Tuple[str, str]] = cursor.execute("SELECT id, image_files FROM album").fetchall()
+        album_images: List[Tuple[str, str]] = cursor.execute(
+            "SELECT id, image_files FROM album"
+        ).fetchall()
         for id, image_files in album_images:
             if image_files:
                 new_image_files: str = ZERO_WIDTH_SPACE.join(

--- a/migrate.py
+++ b/migrate.py
@@ -118,15 +118,6 @@ try:
     conn = connect(db_path, isolation_level=None)
     try:
         cursor = conn.cursor()
-
-        def execute_sql(
-            cursor: sqlite3.Cursor, query: str, params: Optional[Tuple[str, ...]] = None
-        ) -> None:
-            if params:
-                cursor.execute(query, params)
-            else:
-                cursor.execute(query)
-
         cursor.execute("PRAGMA foreign_keys = ON")
         # Since we are messing with media file ids, this will give us trouble.
         # defer checking foreign key constraints until the end
@@ -210,8 +201,7 @@ try:
                     new_track_path.replace(path_Slash_Change[0], path_Slash_Change[1])
 
                 new_id = md5(new_track_path.encode()).hexdigest()
-                execute_sql(
-                    cursor,
+                cursor.execute(
                     "UPDATE media_file SET id = ?, path = ? where id = ?",
                     (new_id, new_track_path, id),
                 )
@@ -219,39 +209,33 @@ try:
                 changes = (new_id, id)
 
                 # Update ids of items that reference to this
-                execute_sql(
-                    cursor,
+                cursor.execute(
                     "UPDATE annotation SET item_id = ? WHERE item_id = ? AND item_type = 'media_file'",
                     changes,
                 )
 
-                execute_sql(
-                    cursor,
+                cursor.execute(
                     "UPDATE media_file_genres SET media_file_id = ? WHERE media_file_id = ?",
                     changes,
                 )
 
-                execute_sql(
-                    cursor,
+                cursor.execute(
                     "UPDATE playlist_tracks SET media_file_id = ? WHERE media_file_id = ?",
                     changes,
                 )
 
-                execute_sql(
-                    cursor,
+                cursor.execute(
                     "UPDATE scrobble_buffer SET media_file_id = ? WHERE media_file_id = ?",
                     changes,
                 )
 
             # Update albums and playlists paths
-            execute_sql(
-                cursor,
+            cursor.execute(
                 "UPDATE album SET paths = REPLACE(paths, ?, ?)",
                 (old_path, new_path),
             )
 
-            execute_sql(
-                cursor,
+            cursor.execute(
                 "UPDATE playlist SET path = REPLACE(path, ?, ?) WHERE path != ''",
                 (old_path, new_path),
             )
@@ -299,7 +283,7 @@ try:
                     ]
                 )
             else:
-                new_image_files = image_files
+                continue
 
             if path_Slash_Change:
                 new_image_files.replace(path_Slash_Change[0], path_Slash_Change[1])

--- a/migrate.py
+++ b/migrate.py
@@ -5,7 +5,6 @@ from os.path import basename, isdir, join
 from pathlib import Path
 from sqlite3 import connect
 from shutil import move as fsmove
-import sqlite3
 from traceback import print_exc
 from typing import List, Literal, NoReturn, Optional, Tuple
 

--- a/migrate.py
+++ b/migrate.py
@@ -99,10 +99,15 @@ new_path: str = args.new_path
 dry_run: bool = args.dry_run
 windowsToLinuxPath: bool = args.windowsToLinuxPath
 linuxToWindowsPath: bool = args.linuxToWindowsPath
+path_Slash_Change: List[str] = []
 
 # Check if both --windowsToLinuxPath and --linuxToWindowsPath are set
 if windowsToLinuxPath and linuxToWindowsPath:
     fail("You can only set one of --windowsToLinuxPath or --linuxToWindowsPath")
+elif windowsToLinuxPath:
+    path_Slash_Change = ["\\", "/"]
+elif linuxToWindowsPath:
+    path_Slash_Change = ["/", "\\"]
 
 command: Literal["move", "migrate", "changeLink"] = args.command
 
@@ -201,13 +206,8 @@ try:
             for id, path in media_files:
                 new_track_path = path.replace(old_path, new_path, 1)
 
-                if windowsToLinuxPath:
-                    new_track_path = new_track_path.replace("\\", "/")
-                if linuxToWindowsPath:
-                    new_track_path = new_track_path.replace(
-                        "/",
-                        "\\",
-                    )
+                if path_Slash_Change:
+                    new_track_path.replace(path_Slash_Change[0], path_Slash_Change[1])
 
                 new_id = md5(new_track_path.encode()).hexdigest()
                 execute_sql(
@@ -268,13 +268,8 @@ try:
         for id, embed, art_paths in albums:
             new_embed_path = embed.replace(old_path, new_path, 1)
 
-            if windowsToLinuxPath:
-                new_embed_path = new_embed_path.replace("\\", "/")
-            if linuxToWindowsPath:
-                new_embed_path = new_embed_path.replace(
-                    "/",
-                    "\\",
-                )
+            if path_Slash_Change:
+                new_embed_path.replace(path_Slash_Change[0], path_Slash_Change[1])
 
             if art_paths:
                 new_paths: str = ZERO_WIDTH_SPACE.join(
@@ -286,13 +281,8 @@ try:
             else:
                 new_paths = art_paths
 
-            if windowsToLinuxPath:
-                new_paths = new_paths.replace("\\", "/")
-            if linuxToWindowsPath:
-                new_paths = new_paths.replace(
-                    "/",
-                    "\\",
-                )
+            if path_Slash_Change:
+                new_paths.replace(path_Slash_Change[0], path_Slash_Change[1])
 
             cursor.execute(
                 "UPDATE album SET embed_art_path = ?, paths = ? WHERE id = ?",
@@ -311,13 +301,8 @@ try:
             else:
                 new_image_files = image_files
 
-            if windowsToLinuxPath:
-                new_image_files = new_image_files.replace("\\", "/")
-            if linuxToWindowsPath:
-                new_image_files = new_image_files.replace(
-                    "/",
-                    "\\",
-                )
+            if path_Slash_Change:
+                new_image_files.replace(path_Slash_Change[0], path_Slash_Change[1])
 
             cursor.execute(
                 "UPDATE album SET image_files = ? WHERE id = ?",

--- a/migrate.py
+++ b/migrate.py
@@ -114,7 +114,9 @@ try:
     try:
         cursor = conn.cursor()
 
-        def execute_sql(cursor: sqlite3.Cursor, query: str, params: str = "None") -> None:
+        def execute_sql(
+            cursor: sqlite3.Cursor, query: str, params: Optional[Tuple[str, ...]] = None
+        ) -> None:
             if params:
                 cursor.execute(query, params)
             else:
@@ -199,9 +201,9 @@ try:
             for id, path in media_files:
                 new_track_path = path.replace(old_path, new_path, 1)
 
-                if args.windowsToLinuxPath:
+                if windowsToLinuxPath:
                     new_track_path = new_track_path.replace("\\", "/")
-                if args.linuxToWindowsPath:
+                if linuxToWindowsPath:
                     new_track_path = new_track_path.replace(
                         "/",
                         "\\",
@@ -260,22 +262,22 @@ try:
         )
 
         # Update albums embed_art_path column
-        albums: List[Tuple[str, str, Optional[str]]] = cursor.execute(
+        albums: List[Tuple[str, str, str]] = cursor.execute(
             "SELECT id, embed_art_path, paths FROM album"
         ).fetchall()
         for id, embed, art_paths in albums:
             new_embed_path = embed.replace(old_path, new_path, 1)
 
-            if args.windowsToLinuxPath:
+            if windowsToLinuxPath:
                 new_embed_path = new_embed_path.replace("\\", "/")
-            if args.linuxToWindowsPath:
+            if linuxToWindowsPath:
                 new_embed_path = new_embed_path.replace(
                     "/",
                     "\\",
                 )
 
             if art_paths:
-                new_paths: Optional[str] = ZERO_WIDTH_SPACE.join(
+                new_paths: str = ZERO_WIDTH_SPACE.join(
                     [
                         path.replace(old_path, new_path, 1)
                         for path in art_paths.split(ZERO_WIDTH_SPACE)
@@ -284,9 +286,9 @@ try:
             else:
                 new_paths = art_paths
 
-            if args.windowsToLinuxPath:
+            if windowsToLinuxPath:
                 new_paths = new_paths.replace("\\", "/")
-            if args.linuxToWindowsPath:
+            if linuxToWindowsPath:
                 new_paths = new_paths.replace(
                     "/",
                     "\\",
@@ -297,12 +299,10 @@ try:
                 (new_embed_path, new_paths, id),
             )
         # Update albums image_files column
-        albums: List[Tuple[str, str]] = cursor.execute(
-            "SELECT id, image_files FROM album"
-        ).fetchall()
-        for id, image_files in albums:
+        albums = cursor.execute("SELECT id, image_files FROM album").fetchall()
+        for id, image_files, *_ in albums:
             if image_files:
-                new_image_files: Optional[str] = ZERO_WIDTH_SPACE.join(
+                new_image_files: str = ZERO_WIDTH_SPACE.join(
                     [
                         path.replace(old_path, new_path, 1)
                         for path in image_files.split(ZERO_WIDTH_SPACE)
@@ -311,9 +311,9 @@ try:
             else:
                 new_image_files = image_files
 
-            if args.windowsToLinuxPath:
+            if windowsToLinuxPath:
                 new_image_files = new_image_files.replace("\\", "/")
-            if args.linuxToWindowsPath:
+            if linuxToWindowsPath:
                 new_image_files = new_image_files.replace(
                     "/",
                     "\\",


### PR DESCRIPTION
I used your script as a reference to build off of. I was transferring my music library from a Windows machine to a Linux machine. However, your script only worked with Linux directories. I've updated the script to allow the transfer of Windows to Linux file paths (\\'s to /'s). Also, you didn't update the `image_files` column. The only issue I think this has is that it has redundancies with your migrate function.

The changes worked for me when transferring from a Windows machine to a Linux machine. You would still have to run the full scan, but I don't think it will really find anything different, which is the goal. Thank you for starting the script.